### PR TITLE
[BUGFIX] use canonical-path of live-server root to allow jetty serving content from a symlinked resource-base

### DIFF
--- a/net.certiv.fluent.dt.vis/src/main/java/net/certiv/fluent/dt/vis/server/LiveServer.java
+++ b/net.certiv.fluent.dt.vis/src/main/java/net/certiv/fluent/dt/vis/server/LiveServer.java
@@ -141,7 +141,7 @@ public class LiveServer {
 
 			ResourceHandler rhx = new ResourceHandler();
 			rhx.setDirectoriesListed(false);
-			rhx.setBaseResource(new PathResource(respath));
+			rhx.setBaseResource(new PathResource(respath.toRealPath()));
 
 			ContextHandler chx = new ContextHandler(Strings.SLASH);
 			chx.setHandler(rhx);

--- a/net.certiv.fluent.dt.vis/src/main/java/net/certiv/fluent/dt/vis/server/LiveServer.java
+++ b/net.certiv.fluent.dt.vis/src/main/java/net/certiv/fluent/dt/vis/server/LiveServer.java
@@ -141,7 +141,7 @@ public class LiveServer {
 
 			ResourceHandler rhx = new ResourceHandler();
 			rhx.setDirectoriesListed(false);
-			rhx.setBaseResource(new PathResource(respath.toRealPath()));
+			rhx.setBaseResource(new PathResource(respath));
 
 			ContextHandler chx = new ContextHandler(Strings.SLASH);
 			chx.setHandler(rhx);

--- a/net.certiv.fluent.dt.vis/src/main/java/net/certiv/fluent/dt/vis/util/LiveUtil.java
+++ b/net.certiv.fluent.dt.vis/src/main/java/net/certiv/fluent/dt/vis/util/LiveUtil.java
@@ -155,7 +155,7 @@ public class LiveUtil {
 
 		try {
 			// create "tmp/<ws_context>"
-			File root = FsUtil.createTmpFolder(wctx);
+			File root = FsUtil.createTmpFolder(wctx).getCanonicalFile();
 			FsUtil.deleteTmpFolderOnExit(root);
 
 			// copy "<bundle>/<ws_context>/client.zip" to "tmp/liveview/client.zip"


### PR DESCRIPTION
This fix allows serving from MacOS's symlinked temporary directory.
MacOS symlinks `/var` to `/private/var`. The default temporary directory
on MacOS is `/var/folders/…`, so fluentmark-rendered files can not
be served on MacOS, due to jetty's `AllowedResourceAliasChecker`
which prevents serving files from outside the resource-base.

Using the canonical-path (which includes the realpath) of the
live-server's root solves this issue.

Resolves: https://github.com/grosenberg/Fluentmark/issues/73

Signed-off-by: Stephan Jorek <stephan.jorek@gmail.com>